### PR TITLE
Change title to Frequency Map

### DIFF
--- a/public/frequencymap.xml
+++ b/public/frequencymap.xml
@@ -1,4 +1,4 @@
-<visualization name="Genomic Allele Frequency Map" embeddable="true">
+<visualization name="Frequency Map" embeddable="true">
     <description>Allele Frequency Map using OpenLayers</description>
     <data_sources>
         <data_source>


### PR DESCRIPTION
Use a more generic title to allow reuse for other frequency-location datasets, while keeping the description and all other content centered on Allele Frequencies.